### PR TITLE
Support for static membership (KIP-345) and required member ids (KIP-394)

### DIFF
--- a/aiokafka/client.py
+++ b/aiokafka/client.py
@@ -13,6 +13,7 @@ from aiokafka.conn import create_conn, CloseReason
 from aiokafka.cluster import ClusterMetadata
 from aiokafka.protocol.coordination import FindCoordinatorRequest
 from aiokafka.protocol.produce import ProduceRequest
+from aiokafka.protocol.group import SyncGroupRequest
 from aiokafka.errors import (
     KafkaError,
     ConnectionError,
@@ -566,6 +567,7 @@ class AIOKafkaClient:
         # in descending order. As soon as we find one that works, return it
         test_cases = [
             # format (<broker verion>, <needed struct>)
+            ((2, 3, 0), SyncGroupRequest[0].API_KEY, 3),
             ((2, 1, 0), MetadataRequest[0].API_KEY, 7),
             ((1, 1, 0), FetchRequest[0].API_KEY, 7),
             ((1, 0, 0), MetadataRequest[0].API_KEY, 5),

--- a/aiokafka/consumer/assignors.py
+++ b/aiokafka/consumer/assignors.py
@@ -1,0 +1,25 @@
+from kafka.coordinator.assignors.abstract import AbstractPartitionAssignor
+import abc
+
+class AbstractStaticPartitionAssignor(AbstractPartitionAssignor):
+    """
+    Abstract assignor implementation that also supports static assignments (KIP-345)
+    """
+
+
+    @abc.abstractmethod
+    def assign(self, cluster, members, member_group_instance_ids):
+        """Perform group assignment given cluster metadata, member subscriptions
+           and group_instance_ids
+
+        Arguments:
+            cluster (ClusterMetadata): metadata for use in assignment
+            members (dict of {member_id: MemberMetadata}): decoded metadata for
+                each member in the group.
+            mmember_group_instance_ids members (dict of {member_id: MemberMetadata}): decoded metadata for
+                each member in the group.
+
+        Returns:
+            dict: {member_id: MemberAssignment}
+        """
+        pass

--- a/aiokafka/consumer/consumer.py
+++ b/aiokafka/consumer/consumer.py
@@ -63,6 +63,8 @@ class AIOKafkaConsumer(object):
             committing offsets. If None, auto-partition assignment (via
             group coordinator) and offset commits are disabled.
             Default: None
+        group_instance_id (str or None): name of the group instance ID used for
+            static membership (KIP-345)
         key_deserializer (callable): Any callable that takes a
             raw message key and returns a deserialized key.
         value_deserializer (callable, optional): Any callable that takes a
@@ -219,6 +221,7 @@ class AIOKafkaConsumer(object):
                  bootstrap_servers='localhost',
                  client_id='aiokafka-' + __version__,
                  group_id=None,
+                 group_instance_id=None,
                  key_deserializer=None, value_deserializer=None,
                  fetch_max_wait_ms=500,
                  fetch_max_bytes=52428800,
@@ -277,6 +280,7 @@ class AIOKafkaConsumer(object):
             sasl_kerberos_domain_name=sasl_kerberos_domain_name)
 
         self._group_id = group_id
+        self._group_instance_id = group_instance_id
         self._heartbeat_interval_ms = heartbeat_interval_ms
         self._session_timeout_ms = session_timeout_ms
         self._retry_backoff_ms = retry_backoff_ms
@@ -385,6 +389,7 @@ class AIOKafkaConsumer(object):
             self._coordinator = GroupCoordinator(
                 self._client, self._subscription, loop=self._loop,
                 group_id=self._group_id,
+                group_instance_id=self._group_instance_id,
                 heartbeat_interval_ms=self._heartbeat_interval_ms,
                 session_timeout_ms=self._session_timeout_ms,
                 retry_backoff_ms=self._retry_backoff_ms,

--- a/aiokafka/errors.py
+++ b/aiokafka/errors.py
@@ -412,6 +412,15 @@ class ListenerNotFound(BrokerResponseError):
     )
 
 
+class MemberIdRequired(BrokerResponseError):
+    errno = 79
+    message = 'MEMBER_ID_REQUIRED'
+    description = (
+        'Consumer needs to have a valid member '
+        'id before actually entering group'
+    )
+
+
 def _iter_broker_errors():
     for name, obj in inspect.getmembers(sys.modules[__name__]):
         if inspect.isclass(obj) and issubclass(obj, BrokerResponseError) and \

--- a/aiokafka/protocol/group.py
+++ b/aiokafka/protocol/group.py
@@ -1,0 +1,76 @@
+from __future__ import absolute_import
+
+from kafka.protocol.api import Request, Response
+from kafka.protocol.struct import Struct
+from kafka.protocol.types import Array, Bytes, Int16, Int32, Schema, String
+from kafka.protocol.group import *
+
+class JoinGroupResponse_v5(Response):
+    API_KEY = 11
+    API_VERSION = 5
+    SCHEMA = Schema(
+        ('throttle_time_ms', Int32),
+        ('error_code', Int16),
+        ('generation_id', Int32),
+        ('group_protocol', String('utf-8')),
+        ('leader_id', String('utf-8')),
+        ('member_id', String('utf-8')),
+        ('members', Array(
+            ('member_id', String('utf-8')),
+            ('group_instance_id', String('utf-8')),
+            ('member_metadata', Bytes)))
+    )
+
+
+
+class JoinGroupRequest_v5(Request):
+    API_KEY = 11
+    API_VERSION = 5
+    RESPONSE_TYPE = JoinGroupResponse_v5
+    SCHEMA = Schema(
+        ('group', String('utf-8')),
+        ('session_timeout', Int32),
+        ('rebalance_timeout', Int32),
+        ('member_id', String('utf-8')),
+        ('group_instance_id', String('utf-8')),
+        ('protocol_type', String('utf-8')),
+        ('group_protocols', Array(
+            ('protocol_name', String('utf-8')),
+            ('protocol_metadata', Bytes)))
+    )
+    UNKNOWN_MEMBER_ID = ''
+
+
+JoinGroupRequest = [
+    JoinGroupRequest_v0, JoinGroupRequest_v1, JoinGroupRequest_v2, JoinGroupRequest_v5
+]
+JoinGroupResponse = [
+    JoinGroupResponse_v0, JoinGroupResponse_v1, JoinGroupRequest_v2, JoinGroupResponse_v5
+]
+
+
+class SyncGroupResponse_v3(Response):
+    API_KEY = 14
+    API_VERSION = 3
+    SCHEMA = SyncGroupResponse_v1.SCHEMA
+
+
+class SyncGroupRequest_v3(Request):
+    API_KEY = 14
+    API_VERSION = 3
+    RESPONSE_TYPE = SyncGroupResponse_v3
+    SCHEMA = Schema(
+        ('group', String('utf-8')),
+        ('generation_id', Int32),
+        ('member_id', String('utf-8')),
+        ('group_instance_id', String('utf-8')),
+        ('group_assignment', Array(
+            ('member_id', String('utf-8')),
+            ('member_metadata', Bytes)))
+    )
+
+
+
+SyncGroupRequest = [SyncGroupRequest_v0, SyncGroupRequest_v1, SyncGroupRequest_v3]
+SyncGroupResponse = [SyncGroupResponse_v0, SyncGroupResponse_v1, SyncGroupResponse_v3]
+


### PR DESCRIPTION
  KIP-345 adds static membership support. This means that a short
  period of inactivity of a consumer (e.g. code update) does not trigger
  a rebalance if the consumer registers again within session_timeout_ms.
  For now, only the JoinGroupRequest/Response and SyncGroupRequest/Response
  is adapted (seems to be sufficient to use the new interface).

  One can use this feature by setting the group_instance_id of
  AIOKafkaConsumer to a unique value per group member (and retain the
  value during restarts).

  Also, a new interface for partition assignors (AbstractStaticPartitionAssignor)
  has been added so assignors can use the group_instance_ids of
  all group members. This could be beneficial in containerized deployments, so
  each container could be assigned to its previous partitions after a rebalance occured.

  KIP-394 has been introduced to detect invalid JoinGroupRequests on the broker